### PR TITLE
disabled background event fetch

### DIFF
--- a/src/components/EthLock/AffiliationList.tsx
+++ b/src/components/EthLock/AffiliationList.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { useState, useEffect } from 'react';
-import { validEthAddressList, defaultAddress } from '../../data/affiliationProgram';
+import { firstEthIntroducer, defaultAddress } from '../../data/affiliationProgram';
 import { LockEvent } from '../../types/LockdropModels';
 import { PlmDrop } from '../../types/PlasmDrop';
 import { calculateTotalPlm } from '../../helpers/lockdrop/EthereumLockdrop';
@@ -51,7 +51,7 @@ const AffiliationList: React.FC<Props> = ({ lockData }) => {
 
     function getAffiliationResults(lockData: LockEvent[]) {
         // filter out the 0x00 address from the list
-        const validAddresses = validEthAddressList.filter(address => address !== defaultAddress);
+        const validAddresses = firstEthIntroducer.filter(address => address !== defaultAddress);
 
         // get the lockdrop result
         const lockResults = validAddresses.map(i => {
@@ -81,7 +81,7 @@ const AffiliationList: React.FC<Props> = ({ lockData }) => {
                 <List component="nav" className={classes.listRoot} subheader={<li />}>
                     <li className={classes.listSection}>
                         <ul className={classes.ul}>
-                            <ListSubheader>There are {validEthAddressList.length - 1} affiliators</ListSubheader>
+                            <ListSubheader>There are {firstEthIntroducer.length - 1} introducers</ListSubheader>
                             <Divider />
                             {lockdropResult.map(i => (
                                 <IntroducerBonusesItems key={i.receiver} lockResult={i} />

--- a/src/components/EthLock/LockedEthList.tsx
+++ b/src/components/EthLock/LockedEthList.tsx
@@ -5,22 +5,22 @@ import React from 'react';
 import Web3 from 'web3';
 import SectionCard from '../SectionCard';
 import { LockEvent } from '../../types/LockdropModels';
-import { createStyles, Theme, makeStyles, useTheme } from '@material-ui/core/styles';
-import Typography from '@material-ui/core/Typography';
-import Box from '@material-ui/core/Box';
-import AppBar from '@material-ui/core/AppBar';
-import Tabs from '@material-ui/core/Tabs';
-import Tab from '@material-ui/core/Tab';
-import SwipeableViews from 'react-swipeable-views';
+import { createStyles, Theme, makeStyles } from '@material-ui/core/styles';
+// import Typography from '@material-ui/core/Typography';
+// import Box from '@material-ui/core/Box';
+// import AppBar from '@material-ui/core/AppBar';
+// import Tabs from '@material-ui/core/Tabs';
+// import Tab from '@material-ui/core/Tab';
+// import SwipeableViews from 'react-swipeable-views';
 import CurrentLocks from './CurrentLocks';
-import GlobalLocks from './EthGlobalLocks';
+// import GlobalLocks from './EthGlobalLocks';
 
-interface TabPanelProps {
-    children?: React.ReactNode;
-    dir?: string;
-    index: any;
-    value: any;
-}
+// interface TabPanelProps {
+//     children?: React.ReactNode;
+//     dir?: string;
+//     index: any;
+//     value: any;
+// }
 
 interface LockHistoryProps {
     web3: Web3;
@@ -28,29 +28,29 @@ interface LockHistoryProps {
     lockData: LockEvent[];
 }
 
-function TabPanel(props: TabPanelProps) {
-    const { children, value, index, ...other } = props;
+// function TabPanel(props: TabPanelProps) {
+//     const { children, value, index, ...other } = props;
 
-    return (
-        <Typography
-            component="div"
-            role="tabpanel"
-            hidden={value !== index}
-            id={`full-width-tabpanel-${index}`}
-            aria-labelledby={`full-width-tab-${index}`}
-            {...other}
-        >
-            {value === index && <Box p={3}>{children}</Box>}
-        </Typography>
-    );
-}
+//     return (
+//         <Typography
+//             component="div"
+//             role="tabpanel"
+//             hidden={value !== index}
+//             id={`full-width-tabpanel-${index}`}
+//             aria-labelledby={`full-width-tab-${index}`}
+//             {...other}
+//         >
+//             {value === index && <Box p={3}>{children}</Box>}
+//         </Typography>
+//     );
+// }
 
-function a11yProps(index: any) {
-    return {
-        id: `full-width-tab-${index}`,
-        'aria-controls': `full-width-tabpanel-${index}`,
-    };
-}
+// function a11yProps(index: any) {
+//     return {
+//         id: `full-width-tab-${index}`,
+//         'aria-controls': `full-width-tabpanel-${index}`,
+//     };
+// }
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -64,22 +64,22 @@ const useStyles = makeStyles((theme: Theme) =>
 // component that displays the number of tokens and the duration for the lock via Web3
 const LockedEthList: React.FC<LockHistoryProps> = ({ web3, account, lockData }) => {
     const classes = useStyles();
-    const theme = useTheme();
-    const [value, setValue] = React.useState(0);
+    //const theme = useTheme();
+    //const [value, setValue] = React.useState(0);
 
-    const handleChange = (_event: React.ChangeEvent<{}>, newValue: number) => {
-        setValue(newValue);
-    };
+    // const handleChange = (_event: React.ChangeEvent<{}>, newValue: number) => {
+    //     setValue(newValue);
+    // };
 
-    const handleChangeIndex = (index: number) => {
-        setValue(index);
-    };
+    // const handleChangeIndex = (index: number) => {
+    //     setValue(index);
+    // };
 
     return (
         <>
             <SectionCard maxWidth="lg">
                 <div className={classes.tabMenu}>
-                    <AppBar position="static" color="inherit">
+                    {/* <AppBar position="static" color="inherit">
                         <Tabs
                             value={value}
                             onChange={handleChange}
@@ -103,7 +103,8 @@ const LockedEthList: React.FC<LockHistoryProps> = ({ web3, account, lockData }) 
                         <TabPanel value={value} index={1} dir={theme.direction}>
                             <CurrentLocks web3={web3} account={account} lockData={lockData} />
                         </TabPanel>
-                    </SwipeableViews>
+                    </SwipeableViews> */}
+                    <CurrentLocks web3={web3} account={account} lockData={lockData} />
                 </div>
             </SectionCard>
         </>

--- a/src/components/EthLock/LockedEthList.tsx
+++ b/src/components/EthLock/LockedEthList.tsx
@@ -26,6 +26,7 @@ interface LockHistoryProps {
     web3: Web3;
     account: string; // this will be used to get locks for a certain account
     lockData: LockEvent[];
+    onClickRefresh?: () => Promise<void>;
 }
 
 // function TabPanel(props: TabPanelProps) {
@@ -62,7 +63,7 @@ const useStyles = makeStyles((theme: Theme) =>
 );
 
 // component that displays the number of tokens and the duration for the lock via Web3
-const LockedEthList: React.FC<LockHistoryProps> = ({ web3, account, lockData }) => {
+const LockedEthList: React.FC<LockHistoryProps> = ({ web3, account, lockData, onClickRefresh }) => {
     const classes = useStyles();
     //const theme = useTheme();
     //const [value, setValue] = React.useState(0);
@@ -104,7 +105,7 @@ const LockedEthList: React.FC<LockHistoryProps> = ({ web3, account, lockData }) 
                             <CurrentLocks web3={web3} account={account} lockData={lockData} />
                         </TabPanel>
                     </SwipeableViews> */}
-                    <CurrentLocks web3={web3} account={account} lockData={lockData} />
+                    <CurrentLocks web3={web3} account={account} lockData={lockData} onClickRefresh={onClickRefresh} />
                 </div>
             </SectionCard>
         </>

--- a/src/data/affiliationProgram.ts
+++ b/src/data/affiliationProgram.ts
@@ -3,7 +3,7 @@ export const defaultAddress = '0x0000000000000000000000000000000000000000';
 
 export const affiliationRate = 0.01;
 
-const firstEthIntroducer = [
+export const firstEthIntroducer = [
     '0xd8de1f6764e442b8763d313722e9eaee3779707e',
     '0x1d32750e8a03443f008236f7c344fc84821cf690',
     '0xa5a6d551ab33c3920848844b3fe3b27591df8f10',

--- a/src/data/lockInfo.ts
+++ b/src/data/lockInfo.ts
@@ -54,28 +54,6 @@ export const secondLockContract: LockdropContract[] = [
     { type: 'private', address: Lockdrop.networks[5777].address, blockHeight: 0 },
 ];
 
-//todo: add other contract addresses when ready
-export const lockdropContracts = {
-    firstLock: {
-        main: { address: '0x458DaBf1Eff8fCdfbF0896A6Bd1F457c01E2FfD6', blockHeight: 9662816 },
-        ropsten: { address: '0xEEd84A89675342fB04faFE06F7BB176fE35Cb168', blockHeight: 7941301 },
-        private: { address: Lockdrop.networks[5777].address, blockHeight: 0 },
-    },
-    secondLock: {
-        main: { address: '0xa4803f17607B7cDC3dC579083d9a14089E87502b', blockHeight: 10714638 },
-        ropsten: [
-            { address: '0x69e7eb3ab94a10e4f408d842b287c70aa0d11649', blockHeight: 8257718 },
-            { address: '0xa91E04a6ECF202A7628e0c9191676407015F5AF9', blockHeight: 8474518 },
-        ],
-        private: Lockdrop.networks[5777].address,
-    },
-    thirdLock: {
-        main: { address: '0x', blockHeight: 0 },
-        ropsten: { address: '0x', blockHeight: 0 },
-        private: { address: Lockdrop.networks[5777].address, blockHeight: 0 },
-    },
-};
-
 /**
  * used to define the content of the dropdown menu
  */

--- a/src/helpers/lockdrop/EthereumLockdrop.ts
+++ b/src/helpers/lockdrop/EthereumLockdrop.ts
@@ -111,7 +111,7 @@ export async function getAllLockEvents(web3: Web3, instance: Contract): Promise<
         }),
     );
 
-    console.log('calling ethereum');
+    console.log('talking to ethereum');
 
     return Promise.all(
         eventHashes.map(async e => {
@@ -121,6 +121,7 @@ export async function getAllLockEvents(web3: Web3, instance: Contract): Promise<
 
             const transactionString = await Promise.resolve(web3.eth.getBlock(blockHash.blockNumber as number));
             const time = transactionString.timestamp.toString();
+            const _currentFund = await web3.eth.getBalance(lockEvent.lock);
             return {
                 eth: lockEvent.eth as BN,
                 duration: lockEvent.duration as number,
@@ -130,6 +131,7 @@ export async function getAllLockEvents(web3: Web3, instance: Contract): Promise<
                 timestamp: time,
                 lockOwner: blockHash.from,
                 transactionHash: blockHash.hash,
+                currentBalance: new BN(_currentFund),
             } as LockEvent;
         }),
     );

--- a/src/helpers/lockdrop/EthereumLockdrop.ts
+++ b/src/helpers/lockdrop/EthereumLockdrop.ts
@@ -111,6 +111,8 @@ export async function getAllLockEvents(web3: Web3, instance: Contract): Promise<
         }),
     );
 
+    console.log('calling ethereum');
+
     return Promise.all(
         eventHashes.map(async e => {
             // e[0] is lock event and e[1] is block hash

--- a/src/pages/EthRealTimeLockPage.tsx
+++ b/src/pages/EthRealTimeLockPage.tsx
@@ -213,7 +213,7 @@ const EthRealTimeLockPage: React.FC<Props> = ({ lockdropNetwork }) => {
                 toast.error(error.message);
                 console.log(error);
             }
-        }, 5 * 1000);
+        }, 25 * 1000);
 
         // cleanup hook
         return () => {

--- a/src/pages/EthRealTimeLockPage.tsx
+++ b/src/pages/EthRealTimeLockPage.tsx
@@ -200,10 +200,10 @@ const EthRealTimeLockPage: React.FC<Props> = ({ lockdropNetwork }) => {
         const interval = setInterval(async () => {
             try {
                 if (web3 && contract) {
-                    const _allLocks = await ethLockdrop.getAllLockEvents(web3, contract);
-                    if (_allLocks.length > allLockEvents.length) {
-                        setLockEvents(_allLocks);
-                    }
+                    // const _allLocks = await ethLockdrop.getAllLockEvents(web3, contract);
+                    // if (_allLocks.length > allLockEvents.length) {
+                    //     setLockEvents(_allLocks);
+                    // }
                     const _latest = await web3.eth.getBlockNumber();
                     if (_latest !== latestBlock) {
                         setLatestBlock(_latest);
@@ -254,7 +254,7 @@ const EthRealTimeLockPage: React.FC<Props> = ({ lockdropNetwork }) => {
         };
         // we disable next line to prevent change on getClaimParams
         // eslint-disable-next-line
-    }, [contractAddress, web3, account]);
+    }, [contractAddress, account]);
 
     /**
      * called when the user changes MetaMask account
@@ -331,6 +331,8 @@ const EthRealTimeLockPage: React.FC<Props> = ({ lockdropNetwork }) => {
                 }
 
                 await ethLockdrop.submitLockTx(formInputVal, account, contract);
+                const _allLocks = await ethLockdrop.getAllLockEvents(web3, contract);
+                setLockEvents(_allLocks);
                 toast.success(`Successfully locked ${formInputVal.amount} ETH for ${formInputVal.duration} days!`);
             } catch (e) {
                 toast.error(e.message.toString());

--- a/src/types/LockdropModels.ts
+++ b/src/types/LockdropModels.ts
@@ -71,6 +71,7 @@ export interface LockEvent {
     timestamp: string; // in Unix epoch seconds
     lockOwner: string; // locker's address
     transactionHash: string;
+    currentBalance: BN; // how much funds the contract has now
 }
 
 // option data is the type that is going to be passed to the component


### PR DESCRIPTION
this disables the global lock list and lock background fetches to reduce API calls to the chain. This is just a quick patch before we launch a full patch since we still want the users to interact with the page.

A separate PR will make further optimizations with the global lock list and more.

**This patch will not solve the MetaMask RPC, it simply reduces the number of calls and removes the global lock list**

This page will only talk to Ethereum when:
- the user enters the page
- the user changes the contract address (Dusty only)
- the user submits a lock transaction to the contract
- the user tries to unlock the lock (after the lock time is over)