### PR TITLE
changed app portal link

### DIFF
--- a/src/components/ClaimStatus.tsx
+++ b/src/components/ClaimStatus.tsx
@@ -298,7 +298,9 @@ const ClaimStatus: React.FC<Props> = ({
                         </IonItem>
                         <IonItem>
                             <IonButton
-                                href="https://polkadot.js.org/apps/#/accounts"
+                                href={`https://polkadot.js.org/apps/?rpc=wss://rpc.${
+                                    plasmNetwork === 'Dusty' ? 'dusty.' : ''
+                                }plasmnet.io/#/accounts`}
                                 rel="noopener noreferrer"
                                 target="_blank"
                                 slot="start"

--- a/src/components/ClaimStatus.tsx
+++ b/src/components/ClaimStatus.tsx
@@ -298,7 +298,7 @@ const ClaimStatus: React.FC<Props> = ({
                         </IonItem>
                         <IonItem>
                             <IonButton
-                                href="https://apps.plasmnet.io/#/accounts"
+                                href="https://polkadot.js.org/apps/#/accounts"
                                 rel="noopener noreferrer"
                                 target="_blank"
                                 slot="start"


### PR DESCRIPTION
changes the Plasm Network portal link from https://apps.plasmnet.io to https://polkadot.js.org/apps

one issue: polkadotjs apps does not support hard linking networks, so it's hard to display Plasm Network as the default page and user could accidentally create a substrate account from a different network and use that to claim their tokens (but the address prefix check will prevent them from actually using it).

edit: looks like they fixed it! https://github.com/polkadot-js/apps/pull/3706