### PR TITLE
added claim deadline to display the days

### DIFF
--- a/src/components/RealtimeLockdrop/ClaimStatus.tsx
+++ b/src/components/RealtimeLockdrop/ClaimStatus.tsx
@@ -132,9 +132,9 @@ const ClaimStatus: React.FC<Props> = ({
 
     const lockdropEndEst = useMemo(() => {
         const expectedBTime = 10;
-        const secondsLeft = lockdropBoundLeft > 0 ? lockdropBoundLeft * expectedBTime : 0;
+        const secondsLeft = Math.max(lockdropBoundLeft * expectedBTime, 0);
         const tillEnd = moment.duration(secondsLeft, 'seconds');
-        return `${tillEnd.hours()}h:${tillEnd.minutes()}m`;
+        return `${tillEnd.days()}d:${tillEnd.hours()}h:${tillEnd.minutes()}m`;
     }, [lockdropBoundLeft]);
 
     const fetchLockData = useCallback(
@@ -337,7 +337,7 @@ const ClaimStatus: React.FC<Props> = ({
                     {lockdropBoundLeft > 0
                         ? `${lockdropBoundLeft.toLocaleString(
                               'en',
-                          )} blocks (${lockdropEndEst} or more) until the lockdrop claim ends`
+                          )} blocks (${lockdropEndEst}) until the lockdrop claim ends`
                         : 'Lockdrop claim season has ended'}
                 </Typography>
             )}


### PR DESCRIPTION
This fixes a UI display bug where only the hours and minutes of the lockdrop claim expiration was shown, while the number of days was hidden.