### PR TITLE
changed cache endpoint

### DIFF
--- a/src/helpers/lockdrop/EthereumLockdrop.ts
+++ b/src/helpers/lockdrop/EthereumLockdrop.ts
@@ -63,7 +63,7 @@ export async function getMessageSignature(web3: Web3, message: string, asSigPara
  * @param contractAddr contract address that emits the event
  */
 export const fetchEventsFromCache = async (contractAddr: string) => {
-    const api = `https://raw.githubusercontent.com/hoonsubin/plasm-scripts/master/src/data/cache/cache-${contractAddr.slice(
+    const api = `https://raw.githubusercontent.com/hoonsubin/plasm-scripts/a4ea5d1f1e35ba7d370c46738bc485fc5164b376/src/data/cache/cache-${contractAddr.slice(
         0,
         6,
     )}.json`;

--- a/src/helpers/lockdrop/EthereumLockdrop.ts
+++ b/src/helpers/lockdrop/EthereumLockdrop.ts
@@ -63,7 +63,10 @@ export async function getMessageSignature(web3: Web3, message: string, asSigPara
  * @param contractAddr contract address that emits the event
  */
 export const fetchEventsFromCache = async (contractAddr: string) => {
-    const api = `https://cache.plasmnet.io/locks/cache-${contractAddr.slice(0, 6)}.json`;
+    const api = `https://raw.githubusercontent.com/hoonsubin/plasm-scripts/master/src/data/cache/cache-${contractAddr.slice(
+        0,
+        6,
+    )}.json`;
 
     const res = await fetch(api);
 


### PR DESCRIPTION
this changes the lockdrop cache data from the self-hosted server to the cache script application repository
from <https://cache.plasmnet.io/locks> to <https://raw.githubusercontent.com/hoonsubin/plasm-scripts/a4ea5d1f1e35ba7d370c46738bc485fc5164b376/src/data/cache> (using commit hash `a4ea5d1f1e35ba7d370c46738bc485fc5164b376`)